### PR TITLE
Covariance weighted calculus for one row array

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,28 @@ on:
     types: [created]
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install numpy Cython pytest
+      - name: Install catii
+        run: pip install -e .
+      - name: Run tests
+        run: python -m pytest tests/ -v
+
   pypi:
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     package_dir={"": "src"},
     include_package_data=True,
     setup_requires=["setuptools>=18.0", "Cython>=0.20"],
-    install_requires=["numpy>=1.15.2"],
+    install_requires=["numpy>=1.15.2,<2"],
     tests_require=["pytest"],
     ext_modules=ext_modules,
     entry_points={},

--- a/src/catii/xfuncs.py
+++ b/src/catii/xfuncs.py
@@ -1460,7 +1460,9 @@ class xfunc_covariance(xfunc):
                 aweights = None
 
         if coordinates is None:
-            covs[:] = numpy.cov(arr.T, aweights=aweights)
+            if arr.shape[0] > 1 and arr.shape[1] > 1:
+                covs[:] = numpy.cov(arr.T, aweights=aweights)
+
         else:
             if self.ignore_missing:
                 coordinates = coordinates[self.validity]

--- a/tests/xfuncs/test_xfunc_covariance.py
+++ b/tests/xfuncs/test_xfunc_covariance.py
@@ -606,3 +606,49 @@ class TestXfuncCovarianceMissingness:
                 ],
             ],
         )
+
+
+class TestXfuncCovarianceSingleValidRow:
+    """When only 1 row is valid with ignore_missing=True and weights,
+    numpy.cov divides by 0 degrees of freedom. Due to float imprecision
+    in numpy.average(), X-mean is not exactly zero for some values (e.g. 6),
+    so 0/0 becomes tiny/0 = inf instead of nan.
+
+    The result must be all-missing (NaN), not inf.
+    """
+
+    def test_no_dimensions_returns_inf_as_missing(self):
+        """With no dimensions (coordinates=None), single valid row may produce inf.
+
+        The inf is a float imprecision artifact from numpy.cov with 0 degrees
+        of freedom. The evaluation should be skipped and just return nan
+        """
+        arr = numpy.array(
+            [
+                [20.0, 6.0, 1.0, 20.0, 1.0],
+                [NaN, NaN, NaN, NaN, NaN],
+                [NaN, NaN, NaN, NaN, NaN],
+                [NaN, NaN, NaN, NaN, NaN],
+            ]
+        )
+        validity = numpy.array(
+            [
+                [True, True, True, True, True],
+                [False, False, False, False, False],
+                [False, False, False, False, False],
+                [False, False, False, False, False],
+            ]
+        )
+        weights = numpy.array([0.8484, NaN, NaN, NaN])
+        weights_validity = numpy.array([True, False, False, False])
+
+        covs, valid = xcube([]).covariance(
+            (arr, validity),
+            (weights, weights_validity),
+            ignore_missing=True,
+            return_missing_as=(0.0, False),
+        )
+
+        assert not numpy.any(valid), (
+            f"Expected all-missing validity, got: {valid}"
+        )


### PR DESCRIPTION
This PR handles the scenario for the covariance weighted calculus for a numeric array that has one valid row. 

Extra:
 - fix numpy version requirement (version <2)
 - add test run before the release in the github action